### PR TITLE
WPR-413: scope.results is no longer set to an empty array on keyup. I…

### DIFF
--- a/angucomplete-alt.js
+++ b/angucomplete-alt.js
@@ -71,6 +71,8 @@
       var dropdownEl;
       var compiledDropdownEl;
 
+      scope.results = [];
+
       elem.on('mousedown', function(event) {
         if (event.target.id) {
           mousedownOn = event.target.id;
@@ -515,7 +517,6 @@
       function initResults() {
         scope.showDropdown = displaySearching;
         scope.currentIndex = scope.focusFirst ? 0 : -1;
-        scope.results = [];
       }
 
       function getLocalResults(str) {


### PR DESCRIPTION
…t is only set to an empty array upon linking of the directive and when the suggestions are closed. This prevents the suggestions from disappearing and reappearing everytime the user stops typing, which not only looks bad but may also cause epilepsy in some people. I think this may have been a regression compared to the original angucomplete fork.
